### PR TITLE
Fix ArgumentOutOfRangeException in save file patching

### DIFF
--- a/FactorioSaveGameEnableAchievements/Program.cs
+++ b/FactorioSaveGameEnableAchievements/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Compression;
+using System.IO.Compression;
 using System.Text;
 
 namespace FactorioSaveGameEnableAchivements
@@ -9,11 +9,13 @@ namespace FactorioSaveGameEnableAchivements
         {
             var fileProcessor = new FileProcessor();
             Console.WriteLine("Enter the path to the save file: ");
-            var path = Console.ReadLine().Trim('\"');
+            var path = Console.ReadLine().Trim('"');
             var extractDirectoryPath = $"{Path.GetDirectoryName(path)}\\{Path.GetFileNameWithoutExtension(path)}";
             Console.WriteLine("Extracting save file to: " + extractDirectoryPath);
             ZipFile.ExtractToDirectory(path, extractDirectoryPath, true);
-            var files = Directory.GetFiles(extractDirectoryPath, "level.dat*", SearchOption.AllDirectories).Where(x => !x.EndsWith(".datmetadata") && !x.EndsWith(".bin")).ToArray();
+            var files = Directory.GetFiles(extractDirectoryPath, "level.dat*", SearchOption.AllDirectories)
+                                 .Where(x => !x.EndsWith(".datmetadata") && !x.EndsWith(".bin"))
+                                 .ToArray();
 
             foreach (var file in files)
             {
@@ -22,27 +24,32 @@ namespace FactorioSaveGameEnableAchivements
                 if (asciiString.Contains("command-ran"))
                 {
                     var position = asciiString.IndexOf("command-ran");
-                    var findings = FindPattern(result, [0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-                    var closest = findings.OrderBy(x => position - x).ToList();
-                    if (result[closest[0] - 7] == 1)
-                    {
-                        // achievements are deactivated due to commands, lets activate them
-                        result[closest[0] - 7] = 0;
-                    }
+                    var findings = FindPattern(result, new byte[] { 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff });
+                    var closest = findings.OrderBy(x => Math.Abs(position - x)).ToList();
 
-                    if (result[closest[0] - 6] == 1)
+                    if (closest.Count > 0 && closest[0] - 7 >= 0)
                     {
-                        // achievements are deactivated due to map editor usage, lets activate them
-                        result[closest[0] - 6] = 0;
+                        if (result[closest[0] - 7] == 1)
+                        {
+                            result[closest[0] - 7] = 0;  // activate achievements disabled by commands
+                        }
+                    }
+                    
+                    if (closest.Count > 0 && closest[0] - 6 >= 0)
+                    {
+                        if (result[closest[0] - 6] == 1)
+                        {
+                            result[closest[0] - 6] = 0;  // activate achievements disabled by map editor
+                        }
                     }
 
                     var packed = fileProcessor.PackZLib(result);
-                    File.WriteAllBytes(file, packed); // replace existing
+                    File.WriteAllBytes(file, packed);  // replace existing
                     Console.WriteLine("patched finding");
                 }
             }
             Console.WriteLine("Backing up original save file");
-            File.Move(path, path + ".bak", true); // backup
+            File.Move(path, path + ".bak", true);
             Console.WriteLine("Creating new save file");
             ZipFile.CreateFromDirectory(extractDirectoryPath, path, CompressionLevel.Optimal, false);
             Console.WriteLine("Cleaning up");


### PR DESCRIPTION
- Added checks to prevent accessing invalid indices in the 'closest' list.  
- Ensured the list is not empty before attempting to modify byte arrays.  
- Prevented potential crashes when the pattern is not found in the save file.  